### PR TITLE
Fix upload server stream handling

### DIFF
--- a/upload-server/app.js
+++ b/upload-server/app.js
@@ -24,8 +24,15 @@ app.put('/upload', (req, res) => {
   const writeStream = fs.createWriteStream(targetPath);
   req.pipe(writeStream);
 
-  req.on('end', () => {
+  // 파일 스트림이 완전히 종료된 후 응답을 반환
+  writeStream.on('finish', () => {
     res.status(200).json({ message: '파일 저장 성공', filename });
+  });
+
+  // 업로드 과정에서 발생한 오류 처리
+  writeStream.on('error', (err) => {
+    console.error('파일 저장 실패:', err);
+    res.status(500).json({ error: '파일 저장 실패', detail: err.message });
   });
 
   req.on('error', (err) => {


### PR DESCRIPTION
## Summary
- ensure the Node.js upload server waits for the file stream to finish
- handle stream errors properly

## Testing
- `mvnw -q test` *(fails: could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6846a26c8788832f98766c3ce728a405